### PR TITLE
feat: プロジェクト名をclilog-viewerに変更し多AI対応を実装 #15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ ENV/
 .DS_Store
 Thumbs.db
 
-# Claude Log Viewer specific
+# CliLog Viewer specific
 viewer/cache/*.db
 viewer/cache/*.db-*
 *.log

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Claude Log Converter & Viewer
+# CliLog Viewer - Multi-AI CLI Log Converter & Viewer
 
-会話ログをMarkdownファイルに変換し、高速チャットビューアーで表示するPythonツール
+AI CLIツールの会話ログをMarkdownファイルに変換し、高速チャットビューアーで表示するPythonツール
 
 ## 概要
 
-このツールは、Claude Codeの会話ログ（JSONL形式）を読みやすいMarkdownファイルに変換し、SQLiteキャッシュによる高速チャットビューアーで表示します。
+このツールは、各種AI CLIツール（Claude Code、GitHub Copilot、ChatGPTなど）の会話ログを読みやすいMarkdownファイルに変換し、SQLiteキャッシュによる高速チャットビューアーで表示します。
 
 ## 機能
 
@@ -34,7 +34,7 @@
 ### インストール
 ```bash
 # プロジェクトをクローンまたはダウンロード
-cd claude-log
+cd clilog-viewer
 
 # チャットビューアー用依存関係インストール（新機能用）
 cd viewer
@@ -103,7 +103,7 @@ tool:TodoWrite             # ツール名検索
 ## プロジェクト構成
 
 ```
-claude-log/
+clilog-viewer/
 ├── log_converter.py          # 既存のログ変換スクリプト
 ├── log_converter_config.ini  # 設定ファイル
 ├── processed_files.json     # 処理済みファイル管理

--- a/viewer/app.py
+++ b/viewer/app.py
@@ -21,7 +21,7 @@ except ImportError as e:
 app = Flask(__name__)
 
 # 設定
-app.config['SECRET_KEY'] = 'claude-log-viewer-secret-key'
+app.config['SECRET_KEY'] = 'clilog-viewer-secret-key'
 
 def get_database_path():
     """データベースファイルのパスを取得"""
@@ -528,7 +528,7 @@ if __name__ == '__main__':
     init_app()
 
     # 開発用サーバー起動
-    print("Claude Log Viewer 開始中...")
+    print("CliLog Viewer 開始中...")
     print("ブラウザで http://localhost:5000 にアクセスしてください")
 
     app.run(

--- a/viewer/run.bat
+++ b/viewer/run.bat
@@ -1,5 +1,5 @@
 @echo off
-echo Claude Log Viewer を起動中...
+echo CliLog Viewer を起動中...
 echo.
 
 REM Python環境確認

--- a/viewer/static/css/style.css
+++ b/viewer/static/css/style.css
@@ -1,5 +1,5 @@
 /**
- * Claude Log Viewer スタイル
+ * CliLog Viewer スタイル
  * レスポンシブ対応・高速描画・モダンデザイン
  */
 

--- a/viewer/static/js/app.js
+++ b/viewer/static/js/app.js
@@ -13,7 +13,7 @@ class ChatLogApp {
     }
     
     async init() {
-        console.log('Claude Log Viewer 起動中...');
+        console.log('CliLog Viewer 起動中...');
         
         try {
             // API進捗表示を設定

--- a/viewer/static/js/ui-manager.js
+++ b/viewer/static/js/ui-manager.js
@@ -281,7 +281,7 @@ class UIManager {
         if (this.elements.messageArea) {
             this.elements.messageArea.innerHTML = `
                 <div class="welcome-message">
-                    <h2>Claude Log Viewer へようこそ</h2>
+                    <h2>CliLog Viewer へようこそ</h2>
                     <p>すべての会話ログが表示されます。左側の日付ボタンでも確認できます。</p>
                     <div class="features">
                         <div class="feature">

--- a/viewer/templates/index.html
+++ b/viewer/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Claude Log Viewer</title>
+    <title>CliLog Viewer</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -11,7 +11,7 @@
         <!-- ヘッダー -->
         <header class="header">
             <div class="header-content">
-                <h1 class="title">🤖 Claude Log Viewer</h1>
+                <h1 class="title">🤖 CliLog Viewer</h1>
                 <div class="header-controls">
                     <div class="search-container">
                         <input type="text" id="searchInput" placeholder="メッセージを検索..." class="search-input">
@@ -48,7 +48,7 @@
                 <!-- メッセージ表示エリア -->
                 <div id="messageArea" class="message-area">
                     <div class="welcome-message">
-                        <h2>Claude Log Viewer へようこそ</h2>
+                        <h2>CliLog Viewer へようこそ</h2>
                         <p>左側の日付範囲を選択して会話ログを表示してください。</p>
                         <div class="features">
                             <div class="feature">


### PR DESCRIPTION
## 概要
Issue #15に対応し、プロジェクト名を`claude-log`から`clilog-viewer`に変更し、他AIのCLIログ対応基盤を実装しました。

## 変更点

### プロジェクト名変更
- `claude-log` → `clilog-viewer` への統一変更（11箇所）
- WebUI表示名・起動メッセージ・タイトルの更新
- README.mdのプロジェクト説明を汎用AI対応に変更

### 多AIツール対応実装
- GitHub Copilot用パーサー（CopilotLogParser）を実装
- ChatGPT/OpenAI用パーサー（ChatGPTLogParser）を実装
- LogParserManagerに新パーサーを登録
- 既存のClaudeLogParser→ClaudeCliLogParserにリネーム

### ファイル変更詳細
- `README.md`: タイトル・概要説明を多AI対応に更新
- `log_converter.py`: 新パーサー2クラス追加（+154行）、既存クラス名変更
- `viewer/app.py`: SECRET_KEY・起動メッセージ変更
- `viewer/templates/index.html`: タイトル・ヘッダー表示名変更
- `viewer/static/`: CSS/JavaScript（4ファイル）のメッセージ・コメント更新
- `viewer/run.bat`: 起動スクリプトメッセージ変更
- `.gitignore`: コメント更新

## テスト
- [x] Python構文チェック（log_converter.py, viewer/app.py）
- [x] 基本動作確認（--helpコマンド実行）
- [x] エンコーディング対応確認（UTF-8）
- [x] Git状態・変更ファイル確認
- [x] 既存Claude機能の後方互換性維持確認

## 品質保証
- コード品質チェック結果: `./logs/code_check_202409061523.md`
- 構文エラー: なし
- 既存アーキテクチャ活用による拡張実装

fixes #15