### PR TITLE
docs: プロジェクト名をclilog-viewerに統一 #18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ ENV/
 .DS_Store
 Thumbs.db
 
-# CliLog Viewer specific
+# clilog-viewer specific
 viewer/cache/*.db
 viewer/cache/*.db-*
 *.log

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CliLog Viewer - Multi-AI CLI Log Converter & Viewer
+# clilog-viewer - Multi-AI CLI Log Converter & Viewer
 
 AI CLIツールの会話ログをMarkdownファイルに変換し、高速チャットビューアーで表示するPythonツール
 

--- a/viewer/templates/index.html
+++ b/viewer/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CliLog Viewer</title>
+    <title>clilog-viewer</title>
     <link rel="stylesheet" href="/static/css/style.css">
     <link rel="stylesheet" href="/static/css/realtime.css">
 </head>
@@ -12,7 +12,7 @@
         <!-- ヘッダー -->
         <header class="header">
             <div class="header-content">
-                <h1 class="title">🤖 CliLog Viewer</h1>
+                <h1 class="title">🤖 clilog-viewer</h1>
                 <div class="header-controls">
                     <!-- リアルタイムモード切り替え -->
                     <div class="mode-selector">


### PR DESCRIPTION
## 概要
プロジェクト名の表記を「CliLog Viewer」から「clilog-viewer」に統一

## 変更点

### ドキュメント
- `.gitignore`: コメント内のプロジェクト名を統一
- `README.md`: プロジェクト名をclilog-viewerに統一  
- `viewer/templates/index.html`: タイトル表記をclilog-viewerに統一

## テスト
- ✅ 構文チェック（Python）
- ✅ プロジェクト名の表記統一確認

fixes #18