### PR TITLE
fix: bare except文を具体的な例外処理に改善 #48

### DIFF
--- a/log_converter.py
+++ b/log_converter.py
@@ -11,8 +11,11 @@ from pathlib import Path
 import configparser
 import os
 import getpass
+import logging
 from abc import ABC, abstractmethod
 from typing import Optional, List, Dict, Any
+
+logger = logging.getLogger(__name__)
 
 
 class BaseLogParser(ABC):
@@ -145,13 +148,14 @@ def format_timestamp(timestamp_str):
     try:
         # UTC時刻をパース
         dt = datetime.fromisoformat(timestamp_str.replace('Z', '+00:00'))
-        
+
         # JSTに変換（UTC+9）
         jst = timezone(timedelta(hours=9))
         dt_jst = dt.astimezone(jst)
-        
+
         return dt_jst.strftime('%Y-%m-%d %H:%M:%S JST')
-    except:
+    except (ValueError, AttributeError) as e:
+        logger.warning(f"タイムスタンプのパースエラー: {timestamp_str} - {e}")
         return timestamp_str
 
 
@@ -160,14 +164,15 @@ def convert_utc_to_jst(timestamp_str):
     try:
         # UTC時刻をパース
         dt = datetime.fromisoformat(timestamp_str.replace('Z', '+00:00'))
-        
+
         # JSTに変換（UTC+9）
         jst = timezone(timedelta(hours=9))
         dt_jst = dt.astimezone(jst)
-        
+
         # SQLiteで使いやすい形式で返す
         return dt_jst.strftime('%Y-%m-%d %H:%M:%S')
-    except:
+    except (ValueError, AttributeError) as e:
+        logger.warning(f"タイムスタンプの変換エラー: {timestamp_str} - {e}")
         # パースできない場合は元の形式を返す
         return timestamp_str
 
@@ -178,7 +183,8 @@ def parse_message_date(timestamp_str):
         # UTC時刻をパース
         dt = datetime.fromisoformat(timestamp_str.replace('Z', '+00:00'))
         return dt
-    except:
+    except (ValueError, AttributeError) as e:
+        logger.warning(f"日付の解析エラー: {timestamp_str} - {e}")
         return None
 
 

--- a/viewer/realtime_reader.py
+++ b/viewer/realtime_reader.py
@@ -6,6 +6,7 @@
 import json
 import os
 import time
+import logging
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
 from typing import List, Dict, Any, Optional, Callable
@@ -19,6 +20,8 @@ except ImportError:
     WATCHDOG_AVAILABLE = False
     print("警告: watchdogライブラリが利用できません。ファイル監視機能は無効です。")
 import threading
+
+logger = logging.getLogger(__name__)
 
 
 class JSONLFileReader:
@@ -196,14 +199,15 @@ class JSONLFileReader:
         try:
             # UTC時刻をパース
             dt = datetime.fromisoformat(timestamp_str.replace('Z', '+00:00'))
-            
+
             # JSTに変換（UTC+9）
             jst = timezone(timedelta(hours=9))
             dt_jst = dt.astimezone(jst)
-            
+
             # SQLiteで使いやすい形式で返す
             return dt_jst.strftime('%Y-%m-%d %H:%M:%S')
-        except:
+        except (ValueError, AttributeError) as e:
+            logger.warning(f"タイムスタンプの変換エラー: {timestamp_str} - {e}")
             # パースできない場合は現在時刻を返す
             return datetime.now().strftime('%Y-%m-%d %H:%M:%S')
 


### PR DESCRIPTION
## 概要

Issue #48で報告されたbare except文（`except:`）を具体的な例外型を指定した適切なエラーハンドリングに改善しました。

## 修正内容

### 修正箇所（4箇所）

#### log_converter.py
1. **format_timestamp (154行目)**
   - タイムスタンプのパース処理
   - `ValueError, AttributeError`を明示的に捕捉
   - エラーログを追加

2. **convert_utc_to_jst (170行目)**
   - UTCからJSTへの変換処理
   - `ValueError, AttributeError`を明示的に捕捉
   - エラーログを追加

3. **parse_message_date (181行目)**
   - 日付解析処理
   - `ValueError, AttributeError`を明示的に捕捉
   - エラーログを追加

#### viewer/realtime_reader.py
4. **_convert_utc_to_jst (206行目)**
   - タイムスタンプ変換処理
   - `ValueError, AttributeError`を明示的に捕捉
   - エラーログを追加

### 追加変更
- 両ファイルに`logging`モジュールを追加
- 各ファイルに`logger = logging.getLogger(__name__)`を設定
- エラー発生時に`logger.warning()`でログ出力

## 効果

1. **エラー追跡の改善**: エラー発生時に詳細な情報がログに記録され、デバッグが容易に
2. **安全性の向上**: `KeyboardInterrupt`や`SystemExit`などのシステム例外を誤って捕捉しなくなった
3. **保守性の向上**: 例外の種類と詳細が明確になり、問題の特定が迅速化

## テスト

- Pythonの構文チェック（`python -m py_compile`）でエラーなし
- bare except文が全て削除されたことを確認（`grep -n "except:"`で0件）

## チェックリスト

- [x] log_converter.py の3箇所を修正
- [x] realtime_reader.py の1箇所を修正
- [x] loggingモジュールのセットアップ
- [x] 構文チェック実施
- [x] bare except文の残存確認

## 関連Issue

Closes #48