### PR TITLE
fix: 初期起動時に最新ログが読み込まれない問題を修正 #50

### DIFF
--- a/viewer/api/routes_database.py
+++ b/viewer/api/routes_database.py
@@ -151,13 +151,20 @@ def init_database_routes(db_manager: DatabaseManager):
 
         results = db_manager.search_by_date_range(start_date, end_date, limit)
 
-        return jsonify({
+        response = jsonify({
             'success': True,
             'results': results,
             'start_date': start_date,
             'end_date': end_date,
             'total': len(results)
         })
+
+        # キャッシュ無効化ヘッダーを追加
+        response.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
+        response.headers['Pragma'] = 'no-cache'
+        response.headers['Expires'] = '0'
+
+        return response
 
     @database_bp.route('/date-range')
     def get_date_range():
@@ -171,10 +178,17 @@ def init_database_routes(db_manager: DatabaseManager):
 
             date_range = db_manager.get_date_range()
 
-            return jsonify({
+            response = jsonify({
                 'success': True,
                 **date_range
             })
+
+            # キャッシュ無効化ヘッダーを追加
+            response.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
+            response.headers['Pragma'] = 'no-cache'
+            response.headers['Expires'] = '0'
+
+            return response
 
         except Exception as e:
             return jsonify({

--- a/viewer/static/js/date-filter.js
+++ b/viewer/static/js/date-filter.js
@@ -86,8 +86,10 @@ class DateFilter {
             console.log('loadAllMessages() が呼び出されました');
             this.uiStateManager.showLoading('すべてのメッセージを読み込み中...');
 
-            // まず利用可能な日付範囲を取得
-            const dateRangeResponse = await fetch('/api/date-range');
+            // まず利用可能な日付範囲を取得（キャッシュを使用しない）
+            const dateRangeResponse = await fetch('/api/date-range', {
+                cache: 'no-store'
+            });
             const dateRangeData = await dateRangeResponse.json();
 
             if (
@@ -98,9 +100,10 @@ class DateFilter {
                 throw new Error('日付範囲の取得に失敗しました');
             }
 
-            // 全データを取得（実際のデータベースの全日付範囲）
+            // 全データを取得（実際のデータベースの全日付範囲、キャッシュを使用しない）
             const response = await fetch(
-                `/api/search/date-range?start_date=${dateRangeData.min_date}&end_date=${dateRangeData.max_date}&limit=5000`
+                `/api/search/date-range?start_date=${dateRangeData.min_date}&end_date=${dateRangeData.max_date}&limit=5000`,
+                { cache: 'no-store' }
             );
             console.log('API response received:', response.status);
             const data = await response.json();


### PR DESCRIPTION
## 概要

ブラウザキャッシュにより、初期起動時やリロード時に古いデータが表示され、最新の会話ログが反映されない問題を修正しました。

## 問題の詳細

### 再現手順
1. 会話ログビューアーを起動
2. 何らかの会話ログを表示
3. ビューアーを終了せずに、新しい会話ログをデータベースに追加
4. ブラウザをリロード
5. **期待**: 最新のログまで表示される
6. **実際**: 前回の表示状態（古いデータ）のまま

### 原因
- `/api/date-range`と`/api/search/date-range`のAPIレスポンスがHTTPキャッシュされていた
- ブラウザが前回のレスポンスをキャッシュから返していた

## 変更内容

### フロントエンド修正

**viewer/static/js/date-filter.js**
- `loadAllMessages()`メソッドの2箇所のfetch呼び出しに`cache: 'no-store'`オプションを追加

```javascript
// 修正前
const dateRangeResponse = await fetch('/api/date-range');

// 修正後
const dateRangeResponse = await fetch('/api/date-range', {
    cache: 'no-store'
});
```

### バックエンド修正

**viewer/api/routes_database.py**
- `/api/date-range`エンドポイントにキャッシュ制御ヘッダーを追加
- `/api/search/date-range`エンドポイントにキャッシュ制御ヘッダーを追加

```python
response.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
response.headers['Pragma'] = 'no-cache'
response.headers['Expires'] = '0'
```

## 効果

- ブラウザリロード時に常に最新のログデータが取得される
- 新しいログ追加後、即座に画面に反映される
- HTTPキャッシュによるデータの不整合が完全に解消

## テスト

- [x] Python構文チェック成功
- [x] フロントエンドとバックエンドの両方で対策を実施
- [x] 2つのAPIエンドポイントにキャッシュ無効化を適用

## 影響範囲

- 初期起動時のデータ読み込み
- ページリロード時のデータ取得
- データベースモードでの全ログ表示

## 関連Issue

fixes #50